### PR TITLE
parser: Allows nested keywords

### DIFF
--- a/invenio_query_parser/ast.py
+++ b/invenio_query_parser/ast.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio-Query-Parser.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio-Query-Parser is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -149,6 +149,10 @@ class GreaterEqualOp(UnaryOp):
 
 
 class KeywordOp(BinaryOp):
+    pass
+
+
+class NestedKeywordsRule(BinaryOp):
     pass
 
 

--- a/invenio_query_parser/parser.py
+++ b/invenio_query_parser/parser.py
@@ -94,6 +94,11 @@ class KeywordRule(LeafRule):
     grammar = attr('value', re.compile(r"[\w\d]+(\.[\w\d]+)*"))
 
 
+class NestedKeywordsRule(LeafRule):
+    grammar = attr('value', re.compile(
+        r"(([\w\d]+(\.[\w\d]+)*):\s*)+([\w\d]+(\.[\w\d]+)*)"))
+
+
 class SingleQuotedString(LeafRule):
     grammar = Literal("'"), attr('value', re.compile(r"([^']|\\.)*")), \
         Literal("'")
@@ -186,7 +191,11 @@ KeywordQuery.grammar = [
     (
         attr('left', KeywordRule),
         omit(_, Literal(':'), _),
-        attr('right', KeywordQuery)
+        # FIXME: This should be replaced with KeywordQuery to restore
+        # intented functionality.
+        # Also NestedKeywordsRule class should be removed from
+        # this file, ./ast.py and ./walkers/pypeg_to_ast.py.
+        attr('right', NestedKeywordsRule)
     ),
     (
         attr('left', KeywordRule),

--- a/invenio_query_parser/walkers/pypeg_to_ast.py
+++ b/invenio_query_parser/walkers/pypeg_to_ast.py
@@ -52,6 +52,10 @@ class PypegConverter(object):
     def visit(self, node):
         return ast.Keyword(node.value)
 
+    @visitor(parser.NestedKeywordsRule)
+    def visit(self, node):
+        return ast.Value(node.value)
+
     @visitor(parser.SingleQuotedString)
     def visit(self, node):
         return ast.SingleQuotedValue(node.value)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -281,13 +281,15 @@ class TestParser(object):
 
 
         # Nested searches
-        ("refersto:author:Ellis",
-         KeywordOp(Keyword('refersto'), KeywordOp(Keyword('author'),
-                                                  Value('Ellis')))),
-        ("refersto:refersto:author:Ellis",
-         KeywordOp(Keyword('refersto'),
-                   KeywordOp(Keyword('refersto'),
-                             KeywordOp(Keyword('author'), Value('Ellis'))))),
+        # FIXME: These two tests should be restored when
+        # we implement nested keywords functionality on labs.
+        # ("refersto:author:Ellis",
+        #  KeywordOp(Keyword('refersto'), KeywordOp(Keyword('author'),
+        #                                           Value('Ellis')))),
+        # ("refersto:refersto:author:Ellis",
+        #  KeywordOp(Keyword('refersto'),
+        #            KeywordOp(Keyword('refersto'),
+        #                      KeywordOp(Keyword('author'), Value('Ellis'))))),
         ("refersto:(foo:bar)",
          KeywordOp(Keyword('refersto'), KeywordOp(Keyword('foo'),
                                                   Value('bar')))),


### PR DESCRIPTION
- Forces parser to ignore nested keywords (e.g. t: t: "title")
  and treat everything after the first keyword as a value.
  (addresses inspirehep/inspire-next#470)
- This is a temporary fix to avoid ugly error pages on nested
  keyword searches.

Signed-off-by: Panos Paparrigopoulos panos.paparrigopoulos@cern.ch
