### PR TITLE
global: fix value parsing

### DIFF
--- a/invenio_query_parser/walkers/pypeg_to_ast.py
+++ b/invenio_query_parser/walkers/pypeg_to_ast.py
@@ -106,7 +106,7 @@ class PypegConverter(object):
 
     @visitor(parser.NotKeywordValue)
     def visit(self, node):
-        return ast.Value(node.value)
+        return ast.ValueQuery(ast.Value(node.value))
 
     @visitor(parser.SimpleQuery)
     def visit(self, node, child):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -292,13 +292,15 @@ class TestParser(object):
         #  KeywordOp(Keyword('refersto'),
         #            KeywordOp(Keyword('refersto'),
         #                      KeywordOp(Keyword('author'), Value('Ellis'))))),
+
+
         # Keyword-like values
         ("auzor:me",
-         AndOp(Value('auzor:'), ValueQuery(Value('me')))),
-        ("high-energies: annual",
-         AndOp(Value('high-energies:'), ValueQuery(Value('annual')))),
+         AndOp(ValueQuery(Value('auzor:')), ValueQuery(Value('me')))),
+        ("high-energy: bar",
+         AndOp(ValueQuery(Value('high-energy:')), ValueQuery(Value('bar')))),
         ("au-thor me:",
-         AndOp(ValueQuery(Value('au-thor')), Value('me:'))),
+         AndOp(ValueQuery(Value('au-thor')), ValueQuery(Value('me:')))),
 
 
         # Spires syntax #


### PR DESCRIPTION
- Fixes a bug where a 'keyword-like' value is parsed as a Value()
  instead of a ValueQuery( Value ())

Signed-off-by: Panos Paparrigopoulos panos.paparrigopoulos@cern.ch
