### PR TITLE
WIP spires_to_invenio: author search

### DIFF
--- a/invenio_query_parser/contrib/spires/walkers/spires_to_invenio.py
+++ b/invenio_query_parser/contrib/spires/walkers/spires_to_invenio.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio-Query-Parser.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Invenio-Query-Parser is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -102,6 +102,8 @@ class SpiresToInvenio(object):
     @visitor(SpiresOp)
     def visit(self, node, left, right):
         left.value = SPIRES_KEYWORDS[left.value]
+        if left.value is 'author':
+            return ast.KeywordOp(left, ast.DoubleQuotedValue(right.value))
         return ast.KeywordOp(left, right)
 
     # pylint: enable=W0612,E0102


### PR DESCRIPTION
- Author search with spires syntax will now be interpreted as a
  double-quoted author search.
- Needs to be merged together with:
  - inspirehep/inspire-next#715
  - inspirehep/invenio-search#17

Signed-off-by: Panos Paparrigopoulos panos.paparrigopoulos@cern.ch
