### PR TITLE
spires_syntax: RangeOp support

### DIFF
--- a/invenio_query_parser/contrib/spires/parser.py
+++ b/invenio_query_parser/contrib/spires/parser.py
@@ -139,6 +139,18 @@ class SpiresSimpleQuery(UnaryRule):
     grammar = attr('op', [SpiresKeywordQuery, SpiresValueQuery])
 
 
+class RangeValue(LeafRule):
+    grammar = attr('value', re.compile(r"([^\s\)\(-]|-+[^\s\)\(>])+"))
+
+
+class RangeOperation(BinaryRule):
+    grammar = (
+        attr('left', RangeValue),
+        Literal('->'),
+        attr('right', RangeValue)
+    )
+
+
 class SpiresQuery(ListRule):
     pass
 
@@ -242,6 +254,7 @@ SpiresKeywordQuery.grammar = [
             GreaterQuery,
             LowerEqualQuery,
             LowerQuery,
+            RangeOperation,
             SpiresValue
         ])
     ),

--- a/invenio_query_parser/contrib/spires/walkers/pypeg_to_ast.py
+++ b/invenio_query_parser/contrib/spires/walkers/pypeg_to_ast.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio-Query-Parser.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Invenio-Query-Parser is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -24,8 +24,8 @@
 """SPIRES extended Pypeg to AST converter."""
 
 from invenio_query_parser import ast
-from invenio_query_parser.walkers import pypeg_to_ast
 from invenio_query_parser.visitor import make_visitor
+from invenio_query_parser.walkers import pypeg_to_ast
 
 from .. import parser
 from ..ast import SpiresOp
@@ -51,6 +51,14 @@ class PypegConverter(pypeg_to_ast.PypegConverter):
     @visitor(parser.GreaterEqualQuery)
     def visit(self, node, child):
         return ast.GreaterEqualOp(child)
+
+    @visitor(parser.RangeOperation)
+    def visit(self, node, left, right):
+        return ast.RangeOp(left, right)
+
+    @visitor(parser.RangeValue)
+    def visit(self, node):
+        return ast.Value(node.value)
 
     @visitor(parser.LowerQuery)
     def visit(self, node, child):

--- a/invenio_query_parser/version.py
+++ b/invenio_query_parser/version.py
@@ -30,4 +30,4 @@ This file is imported by ``invenio_query_parser.__init__``, and parsed by
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.3.1.dev20160202"
+__version__ = "0.3.1.dev20160204"


### PR DESCRIPTION
- Spires syntax now supports range operations (e.g. find topcite 100->200).

Signed-off-by: Panos Paparrigopoulos panos.paparrigopoulos@cern.ch
