### PR TITLE
spires_syntax: RangeOp support

### DIFF
--- a/invenio_query_parser/contrib/spires/parser.py
+++ b/invenio_query_parser/contrib/spires/parser.py
@@ -242,6 +242,7 @@ SpiresKeywordQuery.grammar = [
             GreaterQuery,
             LowerEqualQuery,
             LowerQuery,
+            RangeOp,
             SpiresValue
         ])
     ),

--- a/invenio_query_parser/contrib/spires/walkers/pypeg_to_ast.py
+++ b/invenio_query_parser/contrib/spires/walkers/pypeg_to_ast.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio-Query-Parser.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Invenio-Query-Parser is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -24,8 +24,8 @@
 """SPIRES extended Pypeg to AST converter."""
 
 from invenio_query_parser import ast
-from invenio_query_parser.walkers import pypeg_to_ast
 from invenio_query_parser.visitor import make_visitor
+from invenio_query_parser.walkers import pypeg_to_ast
 
 from .. import parser
 from ..ast import SpiresOp

--- a/invenio_query_parser/version.py
+++ b/invenio_query_parser/version.py
@@ -30,4 +30,4 @@ This file is imported by ``invenio_query_parser.__init__``, and parsed by
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.4.2.dev20160221"
+__version__ = "0.4.2.dev20160229"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio-Query-Parser.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Invenio-Query-Parser is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -441,6 +441,12 @@ class TestParser(object):
                           SpiresOp(Keyword('t'), Value('light higgs'))),
                      SpiresOp(Keyword('j'), Value('phys.rev.lett.'))),
                SpiresOp(Keyword('j'), Value('monkey')))),
+
+        # Range Queries
+        ("find topcite 200->300",
+         SpiresOp(Keyword('topcite'), RangeOp(Value('200'), Value('300')))),
+        ("find topcite 200+",
+         SpiresOp(Keyword('topcite'), GreaterEqualOp(Value('200')))),
 
         # Nested searches
         ("find refersto a ellis",


### PR DESCRIPTION
- Spires syntax now supports range operations (e.g. find topcite 100->200).
- # 11 on top of invenio3 version.

Signed-off-by: Panos Paparrigopoulos panos.paparrigopoulos@cern.ch
