### PR TITLE
search: case insensitive keywords

### DIFF
--- a/invenio_query_parser/contrib/spires/parser.py
+++ b/invenio_query_parser/contrib/spires/parser.py
@@ -31,7 +31,7 @@ from .config import SPIRES_KEYWORDS
 
 class SpiresKeywordRule(LeafRule):
     grammar = attr('value', re.compile(r"(%s)\b" % "|".join(
-        SPIRES_KEYWORDS.keys()), re.I))
+        SPIRES_KEYWORDS.keys()), re.IGNORECASE))
 
 
 class SpiresSimpleValue(LeafRule):

--- a/invenio_query_parser/contrib/spires/walkers/spires_to_invenio.py
+++ b/invenio_query_parser/contrib/spires/walkers/spires_to_invenio.py
@@ -105,7 +105,7 @@ class SpiresToInvenio(object):
 
     @visitor(SpiresOp)
     def visit(self, node, left, right):
-        left.value = SPIRES_KEYWORDS[left.value]
+        left.value = SPIRES_KEYWORDS[left.value.lower()]
         if left.value is 'author':
             return ast.KeywordOp(left, ast.DoubleQuotedValue(right.value))
         return ast.KeywordOp(left, right)

--- a/invenio_query_parser/utils.py
+++ b/invenio_query_parser/utils.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import, print_function
 import re
 
 import pkg_resources
+
 from pypeg2 import attr
 
 
@@ -46,12 +47,14 @@ def build_valid_keywords_grammar():
         NotKeywordValue, SimpleQuery, ValueQuery
 
     if HAS_KEYWORDS:
-        KeywordRule.grammar = attr('value', re.compile(
-            r"(\d\d\d\w{{0,3}}|{0})\b".format("|".join(keywords_list), re.I)))
+        KeywordRule.grammar = attr(
+            'value', re.compile(
+                r"(\d\d\d\w{0,3}|%s)\b" %
+                "|".join(keywords_list), re.IGNORECASE))
 
         NotKeywordValue.grammar = attr('value', re.compile(
             r'\b(?!\d\d\d\w{{0,3}}|{0}:)\S+\b:'.format(
-                ":|".join(keywords_list))))
+                ":|".join(keywords_list)), re.IGNORECASE))
 
         SimpleQuery.grammar = attr(
             'op', [NotKeywordValue, KeywordQuery, ValueQuery])

--- a/invenio_query_parser/version.py
+++ b/invenio_query_parser/version.py
@@ -30,4 +30,4 @@ This file is imported by ``invenio_query_parser.__init__``, and parsed by
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.4.2.dev20160229"
+__version__ = "0.4.2.dev20160310"

--- a/invenio_query_parser/walkers/pypeg_to_ast.py
+++ b/invenio_query_parser/walkers/pypeg_to_ast.py
@@ -50,7 +50,7 @@ class PypegConverter(object):
 
     @visitor(parser.KeywordRule)
     def visit(self, node):
-        return ast.Keyword(node.value)
+        return ast.Keyword(node.value.lower())
 
     @visitor(parser.NestedKeywordsRule)
     def visit(self, node):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -98,7 +98,7 @@ class TestParser(object):
         ("999: bar",
          KeywordOp(Keyword('999'), Value('bar'))),
         ("999C5: bar",
-         KeywordOp(Keyword('999C5'), Value('bar'))),
+         KeywordOp(Keyword('999c5'), Value('bar'))),
         ("999__u: bar",
          KeywordOp(Keyword('999__u'), Value('bar'))),
         ("  foo  :  bar  ",
@@ -281,6 +281,16 @@ class TestParser(object):
             OrOp(
                 ValueQuery(Value('bar')),
                 NotOp(KeywordOp(Keyword('foo'), Value('bar'))))),
+
+
+        # Case Sensitivity
+
+        ("author: LEONTSINIS",
+         KeywordOp(Keyword('author'), Value('LEONTSINIS'))),
+        ("AUTHOR: LEONTSINIS",
+         KeywordOp(Keyword('author'), Value('LEONTSINIS'))),
+        ("autHoR: LEONTSINIS",
+         KeywordOp(Keyword('author'), Value('LEONTSINIS'))),
 
 
         # Nested searches
@@ -527,7 +537,7 @@ class TestParser(object):
 
         # Popular queries
         ("arXiv:1004.0648",
-         KeywordOp(Keyword('arXiv'), Value("1004.0648"))),
+         KeywordOp(Keyword('arxiv'), Value("1004.0648"))),
         ("find ea chowdhury, borun d",
          SpiresOp(Keyword('ea'), Value("chowdhury, borun d"))),
         ("(author:'Hiroshi Okada' OR (author:'H Okada' hep-ph) OR "
@@ -556,6 +566,12 @@ class TestParser(object):
          KeywordOp(Keyword('foo.bar'), Value('baz'))),
         ("a.b.c.d.f:bar",
          KeywordOp(Keyword('a.b.c.d.f'), Value('bar'))),
+
+
+        # Case Sensitivity
+        ("FIND A richter, b",
+         SpiresOp(Keyword('A'), Value('richter, b'))),
+
     )
 
 


### PR DESCRIPTION
- Removes case sensitivity from keyword matching.
- Closes inspirehep/invenio-query-parser#12.
- Should be merged with inspirehep/inspire-next#988.

Signed-off-by: Panos Paparrigopoulos panos.paparrigopoulos@cern.ch
