### PR TITLE
parser: # as wildcard

### DIFF
--- a/invenio_query_parser/contrib/spires/walkers/spires_to_invenio.py
+++ b/invenio_query_parser/contrib/spires/walkers/spires_to_invenio.py
@@ -106,7 +106,7 @@ class SpiresToInvenio(object):
     @visitor(SpiresOp)
     def visit(self, node, left, right):
         left.value = SPIRES_KEYWORDS[left.value.lower()]
-        if left.value is 'author':
+        if (left.value is 'author') and (type(right) is not ast.WildcardQuery):
             return ast.KeywordOp(left, ast.DoubleQuotedValue(right.value))
         return ast.KeywordOp(left, right)
 

--- a/invenio_query_parser/parser.py
+++ b/invenio_query_parser/parser.py
@@ -155,7 +155,10 @@ class RangeOp(BinaryRule):
 
 
 class WildcardQuery(LeafRule):
-    grammar = attr('value', re.compile(r"[^\s]+\*(?:\s|$)"))
+    grammar = attr('value', [
+        re.compile(r"[^\s]+\*(?:\s|$)"),
+        re.compile(r"[^\s]+#(?:\s|$)")
+    ])
 
 
 class Value(UnaryRule):


### PR DESCRIPTION
- Now identifies # as a wildcard character.

Signed-off-by: Panos Paparrigopoulos panos.paparrigopoulos@cern.ch
